### PR TITLE
Update compare.md

### DIFF
--- a/compare.md
+++ b/compare.md
@@ -14,8 +14,8 @@
 | по количеству комментариев | :heavy_check_mark: | :heavy_check_mark: |
 | по количеству скачиваний файлов новости | :heavy_check_mark: | :x: |
 | по символьному коду новости | :heavy_check_mark: | :x: |
-| по дате редактирования | :heavy_check_mark: | :x: |
-| по значению допполя | :heavy_check_mark: | :x: |
+| по дате редактирования | :heavy_check_mark: | :heavy_check_mark: |
+| по значению допполя | :heavy_check_mark: | :heavy_check_mark: |
 | по имени заголовка (по алфавиту) | :heavy_check_mark: | :heavy_check_mark: |
 | в случайном порядке | :heavy_check_mark: | :heavy_check_mark: |
 | топ новостей (как в теге {topnews}) | :heavy_check_mark: | :x: |


### PR DESCRIPTION
в DLE 13 и выше есть поддержка следующих параметров для custom новостей 

xfields выводятся все публикации, содержащие указанное в параметре значение дополнительных полей новостей. Допускается также перечисление значений в параметре через запятую. Например, при использовании {custom xfields="значение 1,значение 2"} будут выведены новости, в которых есть дополнительные поля содержащие "значение 1" или "значение 2".


editdate - сортировка новостей по дате редактирования
id_as_list - сортирует публикации так как они указаны в списке для ID публикаций. Например, тег {custom id="3,4,1,2" order="id_as_list"} выведет сначала новость c ID 3 потом 4 потом 1 потом 2.
lastviewed - вывод последних просмотренных пользователем публикаций